### PR TITLE
take care of optimizations in non-200 scenarios

### DIFF
--- a/main.go
+++ b/main.go
@@ -381,11 +381,12 @@ func (a *authorizer) authorize(ctx context.Context, action, accountUsername, org
 	}
 
 	res, err := a.client.Post(a.url, "application/json", bytes.NewBuffer(j))
+	if res != nil {
+		defer res.Body.Close()
+	}
 	if err != nil {
 		return false, fmt.Errorf("failed to make request to AMS endpoint: %w", err)
 	}
-
-	defer res.Body.Close()
 
 	if res.StatusCode/100 != 2 {
 		msg := "got non-200 status from upstream"

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	stdlog "log"
 	"net/http"
@@ -391,6 +392,9 @@ func (a *authorizer) authorize(ctx context.Context, action, accountUsername, org
 	if res.StatusCode/100 != 2 {
 		msg := "got non-200 status from upstream"
 		level.Error(a.logger).Log("msg", msg, "status", res.Status)
+		if _, err = io.Copy(ioutil.Discard, res.Body); err != nil {
+			level.Error(a.logger).Log("msg", "failed to discard response body", "err", err.Error())
+		}
 		return false, &statusCodeError{errors.New(msg), res.StatusCode}
 	}
 


### PR DESCRIPTION
Currently, we only close the response body for non errored requests,
which is not always correct. It's possible to have an non-nil error and
a non-nil response.

Right now we only read the response body when the status code is 2xx. We
need to also read the responses when dealing with other status codes, in
which case the body can simply be discarded.

cc @kakkoyun @bwplotka 