### PR TITLE
test: demonstrate how to delegate authorization

### DIFF
--- a/test/config/access_reviews.json
+++ b/test/config/access_reviews.json
@@ -10,5 +10,11 @@
         "account_username":"up",
         "organization_id":"foo",
         "resource_type":"ObservatoriumMetrics"
+    },
+    {
+        "action":"create",
+        "account_username":"write-only",
+        "organization_id":"bar",
+        "resource_type":"ObservatoriumMetrics"
     }
 ]

--- a/test/config/observatorium.rego
+++ b/test/config/observatorium.rego
@@ -1,0 +1,15 @@
+package observatorium
+
+import input
+
+default allow = false
+
+allow {
+  input.permission == "read"
+  input.resource == "metrics"
+  input.tenant == "test-delegate-authz"
+} else {
+  response := http.send({"method": "post", "url": "http://127.0.0.1:8080/v1/data/observatorium/allow", "body": {"input": input}})
+  response.status_code == 200
+  json.unmarshal(response.raw_body).result == true
+}

--- a/test/config/tenants.yaml
+++ b/test/config/tenants.yaml
@@ -6,3 +6,12 @@ tenants:
     issuerURL: http://localhost:4444/
   opa:
     url: http://127.0.0.1:8080/v1/data/observatorium/allow
+- name: test-delegate-authz
+  id: da27d8b7-1baf-4dd0-a468-55bb4efa601a
+  oidc:
+    clientID: observatorium
+    issuerURL: http://localhost:4444/
+  opa:
+    query: data.observatorium.allow
+    paths:
+      - ./test/config/observatorium.rego


### PR DESCRIPTION
This commit adds a new test to the integration.sh test script that
demonstrates how to conditionally delegate authorization using OPA
policies. In this case, the policy document has rules to automatically
allow all authenticated clients to read metrics and delegates all other
authorization requests to OPA-AMS, e.g. writing metrics.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>