### PR TITLE
Add trace context propagation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,8 @@ require (
 	github.com/openshift/telemeter v0.0.0-20200917214846-895aca154f5c
 	github.com/prometheus/client_golang v1.5.1
 	github.com/spf13/pflag v1.0.5
+	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.16.0
+	go.opentelemetry.io/otel v0.16.0
 	golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5
 	gopkg.in/square/go-jose.v2 v2.5.0 // indirect
 )


### PR DESCRIPTION
This PR takes inspiration from https://github.com/observatorium/api/pull/124 and propagates tracing context. This closes [MON-1543](https://issues.redhat.com/browse/MON-1543).

Verified that traces make it to Jaeger...

![opa-ams](https://user-images.githubusercontent.com/33524269/125492478-f6c86206-ef01-47d1-965e-e5a7eb11c316.png)


Signed-off-by: Ian Billett <ibillett@redhat.com>