### PR TITLE
Emit traces for internal server

### DIFF
--- a/main.go
+++ b/main.go
@@ -317,7 +317,7 @@ func main() {
 
 		s := http.Server{
 			Addr:    cfg.server.listenInternal,
-			Handler: h,
+			Handler: otelhttp.NewHandler(h, "opa-ams-internal", otelhttp.WithTracerProvider(tp)),
 		}
 
 		g.Add(func() error {


### PR DESCRIPTION
This causes the internal server to emit traces.

Tested by building as `docker.io/snible/opa-ams` and making that version run on on @bill3tt 's cluster using `kubectl edit deployment observatorium-observatorium-api`.  With the change, both the internal and K8s health checks logged traces.

cc @pavolloffay