### PR TITLE
Adding support for specifying multiple AMS mappings for a given tenant

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/go-kit/kit v0.10.0
 	github.com/grpc-ecosystem/grpc-gateway v1.14.3 // indirect
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/kr/text v0.2.0 // indirect
 	github.com/metalmatze/signal v0.0.0-20201002154727-d0c16e42a3cf
 	github.com/observatorium/api v0.1.2

--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,9 @@ go 1.14
 require (
 	github.com/campoy/embedmd v1.0.0
 	github.com/coreos/go-oidc v2.2.1+incompatible
+	github.com/efficientgo/core v1.0.0-rc.0
 	github.com/go-kit/kit v0.10.0
 	github.com/grpc-ecosystem/grpc-gateway v1.14.3 // indirect
-	github.com/hashicorp/go-multierror v1.0.0
 	github.com/kr/text v0.2.0 // indirect
 	github.com/metalmatze/signal v0.0.0-20201002154727-d0c16e42a3cf
 	github.com/observatorium/api v0.1.2

--- a/go.sum
+++ b/go.sum
@@ -378,11 +378,13 @@ github.com/hashicorp/consul/api v1.4.0/go.mod h1:xc8u05kyMa3Wjr9eEAsIAo3dg8+LywT
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/consul/sdk v0.4.0/go.mod h1:fY08Y9z5SvJqevyZNy6WWPXiG3KwBPAvlcdx16zZ0fM=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
+github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,8 @@ github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5m
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=
+github.com/efficientgo/core v1.0.0-rc.0 h1:jJoA0N+C4/knWYVZ6GrdHOtDyrg8Y/TR4vFpTaqTsqs=
+github.com/efficientgo/core v1.0.0-rc.0/go.mod h1:kQa0V74HNYMfuJH6jiPiwNdpWXl4xd/K4tzlrcvYDQI=
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -378,13 +380,11 @@ github.com/hashicorp/consul/api v1.4.0/go.mod h1:xc8u05kyMa3Wjr9eEAsIAo3dg8+LywT
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/consul/sdk v0.4.0/go.mod h1:fY08Y9z5SvJqevyZNy6WWPXiG3KwBPAvlcdx16zZ0fM=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-hclog v0.12.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
-github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=

--- a/main.go
+++ b/main.go
@@ -426,13 +426,11 @@ func (a *authorizer) authorize(action string, accountUsername string, allowedOrg
 
 		allowed, err := a.reviewAccessForOrgId(ar)
 
-		if err != nil {
-			errs.Add(err)
-		}
-
 		if allowed {
 			return true, nil
 		}
+
+		errs.Add(err)
 	}
 
 	return false, errs.Err()

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/go-multierror"
 	"io"
 	"io/ioutil"
 	stdlog "log"
@@ -54,7 +55,7 @@ type config struct {
 	amsURL             string
 	logLevel           level.Option
 	logFormat          string
-	mappings           map[string]string
+	mappings           map[string][]string
 	name               string
 	resourceTypePrefix string
 
@@ -151,13 +152,13 @@ func parseFlags() (*config, error) {
 		return nil, fmt.Errorf("invalid OPA rule name: %s", cfg.opa.rule)
 	}
 
-	cfg.mappings = make(map[string]string)
+	cfg.mappings = make(map[string][]string)
 	for _, m := range *mappingsRaw {
 		parts := strings.Split(m, "=")
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("invalid mapping: %q", m)
 		}
-		cfg.mappings[parts[0]] = parts[1]
+		cfg.mappings[parts[0]] = append(cfg.mappings[parts[0]], parts[1])
 	}
 
 	if len(*mappingsPath) > 0 {
@@ -333,7 +334,7 @@ func main() {
 	}
 }
 
-func newHandler(a *authorizer, resourceTypePrefix string, mappings map[string]string) func(http.ResponseWriter, *http.Request) {
+func newHandler(a *authorizer, resourceTypePrefix string, mappings map[string][]string) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "request must be a POST", http.StatusBadRequest)
@@ -371,7 +372,7 @@ func newHandler(a *authorizer, resourceTypePrefix string, mappings map[string]st
 			return
 		}
 
-		organizationID, ok := mappings[req.Input.Tenant]
+		allowedOrganizationIDs, ok := mappings[req.Input.Tenant]
 		if !ok {
 			http.Error(w, "unknown tenant", http.StatusBadRequest)
 			return
@@ -379,7 +380,7 @@ func newHandler(a *authorizer, resourceTypePrefix string, mappings map[string]st
 
 		resourceType := fmt.Sprintf("%s%s", strings.Title(strings.ToLower(resourceTypePrefix)), strings.Title(strings.ToLower(req.Input.Resource)))
 
-		allowed, err := a.authorize(r.Context(), action, req.Input.Subject, organizationID, resourceType)
+		allowed, err := a.authorize(action, req.Input.Subject, allowedOrganizationIDs, resourceType)
 		if err != nil {
 			statusCode := http.StatusInternalServerError
 			if sce, ok := err.(statusCoder); ok {
@@ -412,13 +413,32 @@ type authorizer struct {
 	logger log.Logger
 }
 
-func (a *authorizer) authorize(ctx context.Context, action, accountUsername, organizationID, resourceType string) (bool, error) {
-	ar := ams.AccessReview{
-		Action:          action,
-		AccountUsername: accountUsername,
-		OrganizationID:  organizationID,
-		ResourceType:    resourceType,
+func (a *authorizer) authorize(action string, accountUsername string, allowedOrganizationIDs []string, resourceType string) (bool, error) {
+	var errs error
+
+	for _, orgId := range allowedOrganizationIDs {
+		ar := ams.AccessReview{
+			Action:          action,
+			AccountUsername: accountUsername,
+			OrganizationID:  orgId,
+			ResourceType:    resourceType,
+		}
+
+		allowed, err := a.reviewAccessForOrgId(ar)
+
+		if err != nil {
+			errs = multierror.Append(err, errs)
+		}
+
+		if allowed {
+			return true, nil
+		}
 	}
+
+	return false, errs
+}
+
+func (a *authorizer) reviewAccessForOrgId(ar ams.AccessReview) (bool, error) {
 	j, err := json.Marshal(ar)
 	if err != nil {
 		return false, fmt.Errorf("failed to marshal access review to JSON: %w", err)

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/hashicorp/go-multierror"
 	"io"
 	"io/ioutil"
 	stdlog "log"
@@ -54,7 +55,7 @@ type config struct {
 	amsURL             string
 	logLevel           level.Option
 	logFormat          string
-	mappings           map[string]string
+	mappings           map[string][]string
 	name               string
 	resourceTypePrefix string
 
@@ -151,13 +152,13 @@ func parseFlags() (*config, error) {
 		return nil, fmt.Errorf("invalid OPA rule name: %s", cfg.opa.rule)
 	}
 
-	cfg.mappings = make(map[string]string)
+	cfg.mappings = make(map[string][]string)
 	for _, m := range *mappingsRaw {
 		parts := strings.Split(m, "=")
 		if len(parts) != 2 {
 			return nil, fmt.Errorf("invalid mapping: %q", m)
 		}
-		cfg.mappings[parts[0]] = parts[1]
+		cfg.mappings[parts[0]] = append(cfg.mappings[parts[0]], parts[1])
 	}
 
 	if len(*mappingsPath) > 0 {
@@ -333,7 +334,7 @@ func main() {
 	}
 }
 
-func newHandler(a *authorizer, resourceTypePrefix string, mappings map[string]string) func(http.ResponseWriter, *http.Request) {
+func newHandler(a *authorizer, resourceTypePrefix string, mappings map[string][]string) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "request must be a POST", http.StatusBadRequest)
@@ -371,7 +372,7 @@ func newHandler(a *authorizer, resourceTypePrefix string, mappings map[string]st
 			return
 		}
 
-		organizationID, ok := mappings[req.Input.Tenant]
+		allowedOrganizationIDs, ok := mappings[req.Input.Tenant]
 		if !ok {
 			http.Error(w, "unknown tenant", http.StatusBadRequest)
 			return
@@ -379,7 +380,7 @@ func newHandler(a *authorizer, resourceTypePrefix string, mappings map[string]st
 
 		resourceType := fmt.Sprintf("%s%s", strings.Title(strings.ToLower(resourceTypePrefix)), strings.Title(strings.ToLower(req.Input.Resource)))
 
-		allowed, err := a.authorize(r.Context(), action, req.Input.Subject, organizationID, resourceType)
+		allowed, err := a.authorize(action, req.Input.Subject, allowedOrganizationIDs, resourceType)
 		if err != nil {
 			statusCode := http.StatusInternalServerError
 			if sce, ok := err.(statusCoder); ok {
@@ -412,13 +413,32 @@ type authorizer struct {
 	logger log.Logger
 }
 
-func (a *authorizer) authorize(ctx context.Context, action, accountUsername, organizationID, resourceType string) (bool, error) {
-	ar := ams.AccessReview{
-		Action:          action,
-		AccountUsername: accountUsername,
-		OrganizationID:  organizationID,
-		ResourceType:    resourceType,
+func (a *authorizer) authorize(action string, accountUsername string, allowedOrganizationIDs []string, resourceType string) (bool, error) {
+	var errs error
+
+	for _, orgId := range allowedOrganizationIDs {
+		ar := ams.AccessReview{
+			Action:          action,
+			AccountUsername: accountUsername,
+			OrganizationID:  orgId,
+			ResourceType:    resourceType,
+		}
+
+		allowed, err := a.reviewAccessForOrgId(ar)
+
+		if err != nil {
+			errs = multierror.Append(err, errs)
+		}
+
+		if allowed {
+			return true, nil
+		}
 	}
+
+	return false, errs
+}
+
+func (a *authorizer) reviewAccessForOrgId(ar ams.AccessReview) (bool, error) {
 	j, err := json.Marshal(ar)
 	if err != nil {
 		return false, fmt.Errorf("failed to marshal access review to JSON: %w", err)
@@ -446,6 +466,15 @@ func (a *authorizer) authorize(ctx context.Context, action, accountUsername, org
 	}
 	if err := json.NewDecoder(res.Body).Decode(&accessReviewResponse); err != nil {
 		return false, fmt.Errorf("failed to unmarshal access review response: %w", err)
+	}
+
+	if res.StatusCode/100 != 2 {
+		msg := "got non-200 status from upstream"
+		level.Error(a.logger).Log("msg", msg, "status", res.Status)
+		if _, err = io.Copy(ioutil.Discard, res.Body); err != nil {
+			level.Error(a.logger).Log("msg", "failed to discard response body", "err", err.Error())
+		}
+		return false, &statusCodeError{errors.New(msg), res.StatusCode}
 	}
 
 	return accessReviewResponse.Allowed, nil

--- a/main.go
+++ b/main.go
@@ -468,15 +468,6 @@ func (a *authorizer) reviewAccessForOrgId(ar ams.AccessReview) (bool, error) {
 		return false, fmt.Errorf("failed to unmarshal access review response: %w", err)
 	}
 
-	if res.StatusCode/100 != 2 {
-		msg := "got non-200 status from upstream"
-		level.Error(a.logger).Log("msg", msg, "status", res.Status)
-		if _, err = io.Copy(ioutil.Discard, res.Body); err != nil {
-			level.Error(a.logger).Log("msg", "failed to discard response body", "err", err.Error())
-		}
-		return false, &statusCodeError{errors.New(msg), res.StatusCode}
-	}
-
 	return accessReviewResponse.Allowed, nil
 }
 

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -135,6 +135,7 @@ write_only_token=$(curl \
       --oidc.audience=tollbooth \
       --ams.url=http://127.0.0.1:8082 \
       --ams.mappings=test-oidc=foo \
+      --ams.mappings=test-oidc=foo-bar \
       --ams.mappings=test-delegate-authz=bar \
       --opa.package=observatorium \
       --memcached=localhost:11211 \


### PR DESCRIPTION
Currently, we only support a single AMS organisation mapping per specified tenant configuration. This means that if you want to configure a tenant to authorize for SA's from multiple organisations, this cannot be configured, the first commit reproduces the issue (ae4d608dad).

The solution is to attempt to review authorization for each combination of org-id/action/accountUsername/resourceType present, until either one succeeds or they all fail. 