### PR TITLE
Replace deprecated Ubuntu images with newer alternatives

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
 
   container-push:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:2022.10.1
     steps:
       - checkout
       - run: |
@@ -38,7 +38,7 @@ jobs:
 
   container-release:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:2022.10.1
     steps:
       - checkout
       - run: |


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

This currently seems to be preventing container push / release jobs from running. Replacing deprecated images with Ubuntu 20.04.